### PR TITLE
chore: migrate community links from Discord to CNCF Slack

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
-- name: Get help on OpenChoreo Discord Channel
-  url: https://discord.gg/WZfSUBsc
-  about: "Get help from the community on Discord."
-- name: Engage with developer discussions in OpenChoreo Discord Channel
-  url: https://discord.gg/36eKXn97
-  about: "Engage with the developers on Discord."
+- name: Get help on OpenChoreo Slack Channel
+  url: https://cloud-native.slack.com/archives/C0ABYRG1MND
+  about: "Get help from the community on Slack."
+- name: Engage with developer discussions in OpenChoreo Slack Channel
+  url: https://cloud-native.slack.com/archives/C0ABHT902BY
+  about: "Engage with the developers on Slack."

--- a/profile/README.md
+++ b/profile/README.md
@@ -146,7 +146,7 @@ Whether you’re fixing a bug, improving documentation, or suggesting new featur
 
 - **[Contributor Guide](https://github.com/openchoreo/openchoreo/blob/main/docs/contributors/README.md)** – Learn how to get started.
 - **[Report an Issue](https://github.com/openchoreo/openchoreo/issues)** – Help us improve Choreo.
-- **[Join our Discord](https://discord.gg/asqDFC8suT)** – Be part of the community.
+- **[Join our Slack](https://cloud-native.slack.com/archives/C0ABYRG1MND)** – Be part of the community.
 
 We’re excited to have you onboard!
 


### PR DESCRIPTION
## Purpose

Replace all Discord community references with CNCF Slack channel links following the project's move to CNCF Slack.

## Approach

- Update org profile README: Discord → Slack `#openchoreo` channel
- Update issue template contact links:
  - Community help → `#openchoreo`
  - Developer discussions → `#openchoreo-dev`

## Related Issues

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated community contact channels from Discord to Slack for improved accessibility and support options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->