### PR TITLE
chore: add k3d script version update to release checklist

### DIFF
--- a/.github/ISSUE_TEMPLATE/06_release_template.md
+++ b/.github/ISSUE_TEMPLATE/06_release_template.md
@@ -34,6 +34,7 @@ Skip these steps if you are creating a patch release (example: v1.4.1).
     ```shell
     echo "${MAJOR_VERSION}.${MINOR_VERSION}.${PATCH_VERSION}" > VERSION
     ```
+- [ ] Update the hardcoded versions in the k3d setup scripts (`install/k3d/k3d-prerequisites.sh` and `install/k3d/k3d-observability-plane.sh`) to match the release
 - [ ] Verify whether there are no changes to the `VERSION` file:
     ```shell
     git diff VERSION


### PR DESCRIPTION
## Summary
- Adds a step to update hardcoded versions in `install/k3d/k3d-prerequisites.sh` and `install/k3d/k3d-observability-plane.sh` as part of the release process

## Related
- openchoreo/openchoreo#2901
- openchoreo/openchoreo.github.io#482

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release process documentation to include a reminder for updating hardcoded versions in k3d setup scripts during release cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->