### PR TITLE
docs: fix broken documentation URL in profile README

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -147,7 +147,7 @@ The easiest way to try OpenChoreo is by following the **[Quick Start Guide](http
 
 For a deeper understanding of OpenChoreo's architecture, see **[OpenChoreo Concepts](https://openchoreo.dev/docs/category/concepts/)**.
 
-Visit **[Installation Guide](https://openchoreo.dev/docs/getting-started/single-cluster/)** to learn more about installation methods.
+Visit **[Installation Guide](https://openchoreo.dev/docs/getting-started/try-it-out/on-k3d-locally/)** to learn more about installation methods.
 
 ## Samples
 


### PR DESCRIPTION
## Summary
- Fix broken installation guide link: `getting-started/single-cluster/` → `getting-started/try-it-out/on-k3d-locally/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Installation Guide documentation link to a new resource location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->