### PR TITLE
docs: note e2e gate behaviour in the release issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/06_release_template.md
+++ b/.github/ISSUE_TEMPLATE/06_release_template.md
@@ -14,6 +14,8 @@ type: Task
 
 All workflow dispatch triggers should be run from the **default branch (`main`)** of the respective repository. The workflows auto-resolve the correct target branch at runtime.
 
+> **E2E gate (openchoreo):** every `Release Orchestrator` run is gated on the full e2e suite (~30 min) before the tag is created. To gate up front, cut the branch first with `action: branch`, then run `action: tag` — the gate is reused when the run targets the same commit, so it is not re-run; any new commit (a fix or backport) is gated afresh. `skip_e2e: true` bypasses the gate for declared emergencies only. See the [release guide](https://github.com/openchoreo/openchoreo/blob/main/docs/contributors/release.md#e2e-release-gate).
+
 ---
 
 ### Major/Minor Release


### PR DESCRIPTION
Adds a short note to the release issue template pointing out that the openchoreo `Release Orchestrator` is gated on the full e2e suite, that cutting the branch first (`action: branch`) gates it up front and a same-commit `action: tag` reuses the green gate, and that `skip_e2e` is the emergency bypass. Links to the release guide.

Pairs with openchoreo/openchoreo#3817, which implements the branch-creation gating and reuse.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release process documentation to include enhanced end-to-end testing gates for improved release quality assurance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->